### PR TITLE
Add chrome browser support for web scraping

### DIFF
--- a/ChromeDockerfile
+++ b/ChromeDockerfile
@@ -1,0 +1,39 @@
+FROM eclipse-temurin:17 AS builder
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} web-scraping-kata-0.0.1.jar
+RUN java -Djarmode=layertools -jar web-scraping-kata-0.0.1.jar extract
+
+FROM eclipse-temurin:17-focal
+LABEL authors="github.com/ehayik"
+
+# Install wget, unzip, and gnupg
+RUN apt-get update && \
+    apt-get install -y wget unzip gnupg
+
+# Adding Chrome's official repo to sources.list
+RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list
+
+# Adding Google's public key for apt to verfiy the installation packages
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+
+# Install Google Chrome
+RUN apt-get update && \
+    apt-get install -y google-chrome-stable
+
+# Install latest ChromeDriver
+RUN wget -O /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`/chromedriver_linux64.zip
+RUN unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
+
+# Clean up
+RUN apt autoremove -y && apt autoclean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set up the xvfb (X Virtual Framebuffer)
+ENV DISPLAY=:99
+
+COPY --from=builder dependencies/ ./
+COPY --from=builder snapshot-dependencies/ ./
+COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder application/ ./
+
+ENTRYPOINT ["java", "-Dweb-driver.browser=chrome", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/ChromeDockerfile
+++ b/ChromeDockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && \
     apt-get install -y google-chrome-stable
 
 # Install latest ChromeDriver
-RUN wget -O /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`/chromedriver_linux64.zip
-RUN unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
+RUN wget -O /tmp/chromedriver.zip https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/119.0.6045.105/linux64/chromedriver-linux64.zip
+RUN unzip /tmp/chromedriver.zip chromedriver-linux64/chromedriver -d /usr/local/bin/
 
 # Clean up
 RUN apt autoremove -y && apt autoclean -y && \

--- a/FirefoxDockerfile
+++ b/FirefoxDockerfile
@@ -31,4 +31,4 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]
+ENTRYPOINT ["java", "-Dweb-driver.browser=firefox", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Feel free to explore the project and suggest any improvements.
 ### Running container
 
 1. Run `mvn clean package` to package application in jar file.
-2. Run `docker build -t web-scraping-kata:0.0.1 .`  to build your Docker image.
+2. Run `docker build -f <Browser>Dockerfile -t web-scraping-kata:0.0.1 .`  to build your Docker image.
 3. Run `docker run -d -p 8080:8080 --name web-scraping-kata  web-scraping-kata:0.0.1` to run it.
 
-> **Note:** 
-> The web scrapper will use the _Firefox_ browser installed in your container, and latest _Gecko Driver_ version will be downloaded.
+>**Note**:
+> Replace `<Broswer>` with a supported browser, `Chrome` or `Firefox`.
 
 ### Usage
 


### PR DESCRIPTION

The Dockerfile has now been split into two different files, ChromeDockerfile and FirefoxDockerfile to support web scraping with both Firefox and Chrome browsers. ChromeDockerfile is a new file, and Dockerfile has been renamed to FirefoxDockerfile. Also, the instructions on how to build Docker images in README.md has been updated to reflect these changes. This increases the range of browser support for the web scraping application.