### PR TITLE
Add second level caching to TechnicalReviewService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,17 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>3.1.8</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/github/ehayik/kata/webscraping/Application.java
+++ b/src/main/java/org/github/ehayik/kata/webscraping/Application.java
@@ -3,7 +3,9 @@ package org.github.ehayik.kata.webscraping;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class Application {

--- a/src/main/java/org/github/ehayik/kata/webscraping/technicalreview/TechnicalReviewService.java
+++ b/src/main/java/org/github/ehayik/kata/webscraping/technicalreview/TechnicalReviewService.java
@@ -1,11 +1,13 @@
 package org.github.ehayik.kata.webscraping.technicalreview;
 
 import io.github.resilience4j.retry.annotation.Retry;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.github.ehayik.kata.webscraping.commons.WebPageIllegalStateException;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -14,6 +16,7 @@ public class TechnicalReviewService {
 
     private final TechnicalReviewPageFactory technicalReviewPageFactory;
 
+    @Cacheable("tech-review")
     @Retry(name = "get-technical-review", fallbackMethod = "fallbackToThrowException")
     public Optional<TechnicalReview> getTechnicalReview(String licensePlate) {
         try (TechnicalReviewPage page = technicalReviewPageFactory.create()) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,9 @@
 
 spring:
+  cache:
+    cache-names: tech-review
+    caffeine:
+      spec: maximumSize=500,expireAfterAccess=6m
   threads:
     virtual:
       enabled: true


### PR DESCRIPTION
Caching has been introduced to the TechnicalReview service with added dependencies for spring-boot-starter-cache and caffeine in the pom.xml file. The @Cacheable annotation has been used in the TechnicalReviewService and application configuration has been updated for the cache settings. This will optimize service performance by reducing unnecessary calls.